### PR TITLE
Manual dns upstream

### DIFF
--- a/bin/gateway_sidecar.sh
+++ b/bin/gateway_sidecar.sh
@@ -14,9 +14,10 @@ if [ ! -f /etc/resolv.conf.org ]; then
   echo "/etc/resolv.conf.org written"
 fi
 
-#Get K8S DNS
-K8S_DNS=$(grep nameserver /etc/resolv.conf.org | cut -d' ' -f2)
-
+# Get K8S DNS if not provided from settings
+if [ -z "$K8S_DNS" ]; then
+  K8S_DNS=$(grep nameserver /etc/resolv.conf.org | cut -d' ' -f2)
+fi
 
 cat << EOF > /etc/dnsmasq.d/pod-gateway.conf
 # DHCP server settings

--- a/bin/gateway_sidecar.sh
+++ b/bin/gateway_sidecar.sh
@@ -54,6 +54,15 @@ cat << EOF >> /etc/dnsmasq.d/pod-gateway.conf
 EOF
 fi
 
+if [ ! -z "${DNSMASQ_UPSTREAM_IPS}" ]; then
+for upstream_ip in $DNSMASQ_UPSTREAM_IPS; do
+cat << EOF >> /etc/dnsmasq.d/pod-gateway.conf
+  # Set manual dns upstream IPs
+  server=${upstream_ip}
+EOF
+done
+fi
+
 for local_cidr in $DNS_LOCAL_CIDRS; do
   cat << EOF >> /etc/dnsmasq.d/pod-gateway.conf
   # Send ${local_cidr} DNS queries to the K8S DNS server


### PR DESCRIPTION
**Description of the change**

Ability to set k8s dns and dnsmasq upstream servers.

**Benefits**

OpenVPN wasn't setting dns for the vxlan and my pihole was bombarded by dns requests as it is automatically set in resolv.conf. This way i can provide upstream settings as i wish.

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
